### PR TITLE
feat(rate-limiting) add dark mode, not enforcing rate-limits

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -122,6 +122,7 @@ function RateLimitingHandler:access(conf)
   -- Consumer is identified by ip address or authenticated_credential id
   local identifier = get_identifier(conf)
   local fault_tolerant = conf.fault_tolerant
+  local dark_mode = conf.dark_mode
 
   -- Load current metric for configured period
   local limits = {
@@ -189,7 +190,11 @@ function RateLimitingHandler:access(conf)
     if stop then
       headers = headers or {}
       headers[RETRY_AFTER] = reset
-      return kong.response.error(429, "API rate limit exceeded", headers)
+     if not dark_mode then
+        return kong.response.error(429, "API rate limit exceeded", headers)
+      else
+        kong.log.warn("Dark mode, logging only. Rate limit exceeded with identifier ", identifier)
+      end
     end
 
     if headers then

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -50,6 +50,7 @@ return {
               one_of = { "local", "cluster", "redis" },
           }, },
           { fault_tolerant = { type = "boolean", required = true, default = true }, },
+          { dark_mode = { type = "boolean", required = true, default = false }, },
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },
           { redis_password = { type = "string", len_min = 0 }, },


### PR DESCRIPTION
Rate limiting often needs tuning after meeting production traffic.
Adjusting these can have unexpected consequences. This patch lets
you run rate-limiting in `dark mode`, where it only logs what it
would have done, without enforcing the limit.

Recommended in https://stripe.com/blog/rate-limiters