### PR TITLE
feat(rate-limiting) Optionally don't fall back to ip

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -73,9 +73,16 @@ local function get_identifier(conf)
     if req_path == conf.path then
       identifier = req_path
     end
+
+  elseif conf.limit_by == "ip" then
+    identifier = kong.client.get_forwarded_ip()
   end
 
-  return identifier or kong.client.get_forwarded_ip()
+  if conf.limit_by_fallback then
+    return identifier or kong.client.get_forwarded_ip()
+  else
+    return identifier
+  end
 end
 
 

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -81,7 +81,6 @@ local function get_identifier(conf)
   if conf.limit_by_fallback then
     return identifier or kong.client.get_forwarded_ip()
   else
-    kong.log.err("no identifier: ", identifier)
     return identifier -- can be 'nil' if no previous match, and limit_by_fallback is false
   end
 end

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -81,7 +81,8 @@ local function get_identifier(conf)
   if conf.limit_by_fallback then
     return identifier or kong.client.get_forwarded_ip()
   else
-    return identifier
+    kong.log.err("no identifier: ", identifier)
+    return identifier -- can be 'nil' if no previous match, and limit_by_fallback is false
   end
 end
 
@@ -129,6 +130,18 @@ function RateLimitingHandler:access(conf)
   -- Consumer is identified by ip address or authenticated_credential id
   local identifier = get_identifier(conf)
   local fault_tolerant = conf.fault_tolerant
+  local limit_by_fallback = conf.limit_by_fallback
+
+  -- identifier is 'nil' and opted to not fallback to client ip
+  if identifier == nil and not limit_by_fallback then
+    if fault_tolerant then -- let people through. log and return
+      kong.log.info('no identifier set, and no fallback: not rate-limiting')
+      return
+    else -- not fault-tolerant. log and return an error
+      kong.log.err("no identifier and no fallback:", "returning error")
+      return kong.response.error(500, "Nothing to rate-limit on", headers)
+    end
+  end
 
   -- Load current metric for configured period
   local limits = {

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -84,5 +84,9 @@ return {
       if_field = "config.policy", if_match = { eq = "redis" },
       then_field = "config.redis_timeout", then_match = { required = true },
     } },
+    { conditional = {
+      if_field = "config.limit_by_fallback", if_match = { eq = false },
+      then_field = "config.fault_tolerant", then_match = {required = true },
+    } },
   },
 }

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -41,6 +41,7 @@ return {
               default = "consumer",
               one_of = { "consumer", "credential", "ip", "service", "header", "path" },
           }, },
+          { limit_by_fallback = { type = "boolean", required = true, default = true }, },
           { header_name = typedefs.header_name },
           { path = typedefs.path },
           { policy = {

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -31,6 +31,13 @@ describe("Plugin: rate-limiting (schema)", function()
     assert.is_nil(err)
   end)
 
+  it("proper config validates (limit_by_fallback)", function()
+    local config = { second = 10, limit_by = "path", path = "/request", limit_by_fallback = false }
+    local ok, _, err = v(config, schema_def)
+    assert.truthy(ok)
+    assert.is_nil(err)
+  end)
+
   describe("errors", function()
     it("limits: smaller unit is less than bigger unit", function()
       local config = { second = 20, hour = 10 }

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -1264,7 +1264,7 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
 
-    describe(fmt("#no-fallback Plugin: rate-limiting with no fallback, with fault-tolerant (access - global) with policy: %s [#%s]", policy, strategy), function()
+    describe(fmt("#fallback Plugin: rate-limiting with no fallback, with fault-tolerant (access - global) with policy: %s [#%s]", policy, strategy), function()
       local bp
       local db
 
@@ -1279,6 +1279,8 @@ for _, strategy in helpers.each_strategy() do
             policy            = policy,
             minute            = 6,
             fault_tolerant    = true,
+            limit_by          = "header",
+            header_name       = "X-Forwarded-For",
             limit_by_fallback = false,
             redis_host        = REDIS_HOST,
             redis_port        = REDIS_PORT,
@@ -1302,7 +1304,7 @@ for _, strategy in helpers.each_strategy() do
         assert(db:truncate())
       end)
 
-      it_with_retry("sets no limit", function()
+      it_with_retry("sets no limit when no limit_by header is present", function()
         for i = 1, 6 do
           local res = GET("/status/200", {
             headers = { Host = fmt("test%d.com", i) },
@@ -1320,9 +1322,47 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["x-ratelimit-limit-minute"])
         assert.res_status(200, res)
       end)
+
+      it_with_retry("sets limit when limit_by header is present", function()
+        for i = 1, 6 do
+          local res = GET("/status/200", {
+            headers = {
+              Host = fmt("test%d.com", i),
+              ["X-Forwarded-For"] = "10.0.0.1",
+            },
+          }, 200)
+
+          assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
+          assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
+        end
+
+        -- Additonal request, while limit is 6/minute
+        local res, body = GET("/status/200", {
+          headers = {
+            Host = "test1.com",
+            ["X-Forwarded-For"] = "10.0.0.1",
+          },
+        }, 429)
+
+        assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+        assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
+        local retry = tonumber(res.headers["retry-after"])
+        assert.equal(true, retry <= 60 and retry > 0)
+
+        local reset = tonumber(res.headers["ratelimit-reset"])
+        assert.equal(true, reset <= 60 and reset > 0)
+
+        local json = cjson.decode(body)
+        assert.same({ message = "API rate limit exceeded" }, json)
+      end)
     end)
 
-    describe(fmt("#no-fallback Plugin: rate-limiting with no fallback, non fault-tolerant (access - global) with policy: %s [#%s]", policy, strategy), function()
+    describe(fmt("#fallback Plugin: rate-limiting with no fallback, non fault-tolerant (access - global) with policy: %s [#%s]", policy, strategy), function()
       local bp
       local db
 
@@ -1337,6 +1377,8 @@ for _, strategy in helpers.each_strategy() do
             policy            = policy,
             minute            = 6,
             fault_tolerant    = false,
+            limit_by          = "header",
+            header_name       = "X-Forwarded-For",
             limit_by_fallback = false,
             redis_host        = REDIS_HOST,
             redis_port        = REDIS_PORT,
@@ -1360,7 +1402,7 @@ for _, strategy in helpers.each_strategy() do
         assert(db:truncate())
       end)
 
-      it_with_retry("sets no limit", function()
+      it_with_retry("sets no limit when no limit_by header is present", function()
         for i = 1, 3 do
           local res = GET("/status/200", {
             headers = { Host = fmt("test%d.com", i) },
@@ -1370,7 +1412,45 @@ for _, strategy in helpers.each_strategy() do
           assert.res_status(500, res)
         end
       end)
-    end)
 
+      it_with_retry("sets limit when limit_by header is present", function()
+        for i = 1, 6 do
+          local res = GET("/status/200", {
+            headers = {
+              Host = fmt("test%d.com", i),
+              ["X-Forwarded-For"] = "10.0.0.1",
+            },
+          }, 200)
+
+          assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
+          assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
+        end
+
+        -- Additonal request, while limit is 6/minute
+        local res, body = GET("/status/200", {
+          headers = {
+            Host = "test1.com",
+            ["X-Forwarded-For"] = "10.0.0.1",
+          },
+        }, 429)
+
+        assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+        assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
+        local retry = tonumber(res.headers["retry-after"])
+        assert.equal(true, retry <= 60 and retry > 0)
+
+        local reset = tonumber(res.headers["ratelimit-reset"])
+        assert.equal(true, reset <= 60 and reset > 0)
+
+        local json = cjson.decode(body)
+        assert.same({ message = "API rate limit exceeded" }, json)
+      end)
+
+    end)
   end
 end


### PR DESCRIPTION
We want to rate-limit on a header X-Forwarded-For. When this header
does not exist it usually is an internal service. Falling back to
source ip gives us disastrous results.

This commit adds an option to fail open instead of falling back to ip.
